### PR TITLE
Allow assign in loop

### DIFF
--- a/optpy-generator/src/lib.rs
+++ b/optpy-generator/src/lib.rs
@@ -46,7 +46,7 @@ fn format_statement(
             let target = format_expr(target);
             let value = format_expr(value);
             quote! {
-                #target.assign(#value);
+                #target.assign(#value.shallow_copy());
             }
         }
         Statement::Expression(expr) => {

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -174,3 +174,13 @@ for a, b in A:
 "#,
 ("", "B A\nD C\n")
 }
+
+optpy_integration_test! {
+test_assign_in_loop,
+r#"
+for i in [0, 1, 2]:
+    x = i
+print(x)
+"#,
+("", "2\n")
+}


### PR DESCRIPTION
Fix compile error for assign in loop

```rust
error[E0382]: borrow of moved value: `__v1`
   --> a.rs:328:9
    |
316 |     let mut __v1 = Value::none();
    |         -------- move occurs because `__v1` has type `value::Value`, which does not implement the `Copy` trait
...
328 |         __v1.assign(__v0.pop());
    |         ^^^^^^^^^^^^^^^^^^^^^^^ value borrowed here after move
329 |         __v2.assign(__v1);
    |                     ---- value moved here, in previous iteration of loop
```

We can't move to call `.assign()`