### PR TITLE
Fix self assign

### DIFF
--- a/optpy-std/src/lib.rs
+++ b/optpy-std/src/lib.rs
@@ -81,7 +81,8 @@ pub mod value {
         }
 
         pub fn assign(&mut self, value: Value) {
-            self.inner.replace(value.inner.borrow().clone());
+            let value = value.inner.borrow().clone();
+            self.inner.replace(value);
         }
 
         pub fn count(&self, value: Value) -> Value {

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -174,3 +174,13 @@ for a, b in A:
 "#,
 ("", "B A\nD C\n")
 }
+
+optpy_integration_test! {
+test_assign_self,
+r#"
+x = [0]
+x[0] = x[0]
+print(x[0])
+"#,
+("", "0\n")
+}


### PR DESCRIPTION
The borrow order in `assign` matters when lhs and rhs are the same.