### PR TITLE
Fix len(str)

### DIFF
--- a/optpy-std/src/lib.rs
+++ b/optpy-std/src/lib.rs
@@ -394,7 +394,7 @@ pub mod value {
         pub fn __len(&self) -> Value {
             match self {
                 Value::List(list) => Value::Number(Number::Int64(list.borrow().len() as i64)),
-                Value::String(s) => Value::Number(Number::Int64(s.len() as i64)),
+                Value::String(s) => Value::Number(Number::Int64(s.chars().count() as i64)),
                 _ => unreachable!(),
             }
         }

--- a/tests/test-std.rs
+++ b/tests/test-std.rs
@@ -67,6 +67,7 @@ def test(a):
     }
 
     assert_eq!(test(&Value::from("abcdef")), Value::from(6));
+    assert_eq!(test(&Value::from("あいうえお")), Value::from(5));
     assert_eq!(
         test(&Value::from(vec![Value::from(1), Value::from(2)])),
         Value::from(2)


### PR DESCRIPTION
```python
❯ python3 -c "print(len('あいうえお'))"
5
```